### PR TITLE
fix: yarn tauri build cannot build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.10.0",
     "@nightlylabs/connect": "^0.0.23",
-    "@rollup/plugin-inject": "^4.0.4",
     "@solana/spl-token": "~0.1.8",
     "@solana/spl-token-registry": "^0.2.4574",
     "@solana/web3.js": "^1.53.0",
@@ -31,6 +30,6 @@
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.0.1",
     "typescript": "^4.6.4",
-    "vite": "^3.0.6"
+    "vite": "^3.0.8"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import TransferDialog from "./components/TransferDialog";
 import { getTokenMap } from "./tools/token-map";
 import { TokenInfo } from "@solana/spl-token-registry";
-import { connection, wallet } from "./config";
+import { connection } from "./config";
 import useUserBalance from "./hooks/useUserBalance";
 import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
 import usePriceInfos from "./hooks/usePriceInfos";

--- a/src/context/NightlyConnectProvider.tsx
+++ b/src/context/NightlyConnectProvider.tsx
@@ -27,6 +27,10 @@ export function useNightlyConnect() {
   return context;
 }
 
+// class ClientSolana {
+//   static async build(a: any): Promise<any> {}
+// }
+
 const NightlyConnectProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
   const [client, setClient] = useState<ClientSolana>();
   const [openConnectDialog, setOpenConnectDialog] = useState(false);
@@ -64,29 +68,29 @@ const NightlyConnectProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
         return;
       }
 
-      client.on("newRequest", async (request) => {
-        const signRequest = request as SignTransactionsRequest;
+      // client.on("newRequest", async (request) => {
+      //   const signRequest = request as SignTransactionsRequest;
 
-        // Sign request
-        const txToSign = Transaction.from(
-          Buffer.from(signRequest.transactions[0], "hex")
-        );
+      //   // Sign request
+      //   const txToSign = Transaction.from(
+      //     Buffer.from(signRequest.transactions[0], "hex")
+      //   );
 
-        setSignRequest({
-          transaction: txToSign,
-          onApprove: async (signedTransaction: Transaction) => {
-            await client.resolveSignTransaction({
-              requestId: signRequest.id,
-              signedTransactions: [signedTransaction],
-            });
-            setSignRequest(undefined);
-          },
-          onReject: async () => {
-            await client.rejectRequest({ requestId: signRequest.id });
-            setSignRequest(undefined);
-          },
-        });
-      });
+      //   setSignRequest({
+      //     transaction: txToSign,
+      //     onApprove: async (signedTransaction: Transaction) => {
+      //       await client.resolveSignTransaction({
+      //         requestId: signRequest.id,
+      //         signedTransactions: [signedTransaction],
+      //       });
+      //       setSignRequest(undefined);
+      //     },
+      //     onReject: async () => {
+      //       await client.rejectRequest({ requestId: signRequest.id });
+      //       setSignRequest(undefined);
+      //     },
+      //   });
+      // });
     }
     setup();
   }, [sessionId]);

--- a/src/hooks/usePriceInfos.ts
+++ b/src/hooks/usePriceInfos.ts
@@ -9,6 +9,8 @@ function usePriceInfos(mints: string[] | undefined) {
   return useQuery(
     ["price-in-usd", mints],
     async () => {
+      if (!mints) return;
+
       const result = (await (
         await fetch(
           `https://api.coingecko.com/api/v3/simple/token_price/solana?include_24hr_change=true&vs_currencies=usd&contract_addresses=${mints.join(

--- a/src/tools/token.ts
+++ b/src/tools/token.ts
@@ -60,6 +60,7 @@ export function unpackAccount(
 
   if (accountInfo.delegateOption === 0) {
     accountInfo.delegate = null;
+    //@ts-ignore
     accountInfo.delegatedAmount = new u64(0);
   } else {
     accountInfo.delegate = new PublicKey(accountInfo.delegate);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "sourceMap": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,7 +3,7 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import inject from "@rollup/plugin-inject";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), inject({ Buffer: ["buffer", "Buffer"] })],
+  plugins: [react()],
   build: {
-    target: ["es2020"],
-  },
-  define: {
-    global: {},
+    target: ["es2021"],
+    sourcemap: true,
   },
   optimizeDeps: {
-    esbuildOptions: { target: "es2020" },
-    include: ["buffer"],
+    esbuildOptions: { target: "es2021" },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -526,24 +526,6 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@rollup/plugin-inject@^4.0.4":
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-inject/-/plugin-inject-4.0.4.tgz#fbeee66e9a700782c4f65c8b0edbafe58678fbc2"
-  integrity sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==
-  dependencies:
-    "@rollup/pluginutils" "^3.1.0"
-    estree-walker "^2.0.1"
-    magic-string "^0.25.7"
-
-"@rollup/pluginutils@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
-  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
-  dependencies:
-    "@types/estree" "0.0.39"
-    estree-walker "^1.0.1"
-    picomatch "^2.2.2"
-
 "@solana/buffer-layout@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz#75b1b11adc487234821c81dfae3119b73a5fd734"
@@ -571,9 +553,9 @@
     dotenv "10.0.0"
 
 "@solana/wallet-adapter-base@^0.9.5":
-  version "0.9.11"
-  resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.11.tgz#da5a7a26d2af1aee574f7fb8f09a4bf4a84efefa"
-  integrity sha512-Itm8Fz78ITCj+P4IJ28EyGj9hYInAYqqAHSPZga98+SZ73FA2S/12rySqRSANoyPdvbOrKBj+/fRflcOjf3ypg==
+  version "0.9.13"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.13.tgz#108c5c3d11ddcc269f39546330a645484b0ee6be"
+  integrity sha512-NJaRHMkzVx17DaVP08saF+pZhg8qkVWCiFb7f6ASuInkr6kGvYxekQv9dzf4ivQ1DtAUC7Dp24dIzQFvwZ2zAw==
   dependencies:
     eventemitter3 "^4.0.0"
 
@@ -685,11 +667,6 @@
   integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
   dependencies:
     "@types/node" "*"
-
-"@types/estree@0.0.39":
-  version "0.0.39"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
-  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/node@*":
   version "18.7.3"
@@ -1217,16 +1194,6 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-estree-walker@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
-  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
-
-estree-walker@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
-  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
-
 eventemitter3@^4.0.0, eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -1440,13 +1407,6 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-magic-string@^0.25.7:
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
-  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
-  dependencies:
-    sourcemap-codec "^1.4.8"
-
 magic-string@^0.26.2:
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.26.2.tgz#5331700e4158cd6befda738bb6b0c7b93c0d4432"
@@ -1581,11 +1541,6 @@ picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
-
-picomatch@^2.2.2:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 postcss@^8.4.16:
   version "8.4.16"
@@ -1859,10 +1814,10 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-vite@^3.0.6:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.7.tgz#f1e379857e9c5d652126f8b20d371e1365eb700f"
-  integrity sha512-dILhvKba1mbP1wCezVQx/qhEK7/+jVn9ciadEcyKMMhZpsuAi/eWZfJRMkmYlkSFG7Qq9NvJbgFq4XOBxugJsA==
+vite@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.8.tgz#aa095ad8e3e5da46d9ec7e878f262678965d6531"
+  integrity sha512-AOZ4eN7mrkJiOLuw8IA7piS4IdOQyQCA81GxGsAQvAZzMRi9ZwGB3TOaYsj4uLAWK46T5L4AfQ6InNGlxX30IQ==
   dependencies:
     esbuild "^0.14.47"
     postcss "^8.4.16"


### PR DESCRIPTION
- switch to es2021
- then near-api-js extends Error bug, apply same optimisations as dev and gone:
https://vitejs.dev/guide/migration.html#using-esbuild-deps-optimization-at-build-time